### PR TITLE
Fix error when taxonomy children do not have a status

### DIFF
--- a/add-descendants-as-submenu-items.php
+++ b/add-descendants-as-submenu-items.php
@@ -291,6 +291,10 @@ class Add_Descendants_As_Submenu_Items {
 				$child        = wp_setup_nav_menu_item( $child );
 				$child->db_id = $child->ID;
 
+				if ( empty( $child->status ) ) {
+					$child->status = 'publish';
+				}
+
 				$this->added[ $child->ID ] = true; // We'll need this later
 
 				// Set the parent menu item.


### PR DESCRIPTION
Fixes an error in customizer when child taxonomy menu items do not have a status. I was able to reproduce this issue without Elementor active.

Credit for fix is from Jamma in https://alex.blog/wordpress-plugins/add-descendants-as-submenu-items/comment-page-2/#comment-240480.

## Testing / Steps to Reproduce Issue
- On a fresh install, add a category with a few child categories.
- Create a new post and assign it the top category and child categories (just to activate them).
- Create a new menu. 
- Add the top category to the menu.
- Save and refresh the page.
- Edit that category menu item and check `Automatically add all descendants as submenu items`. Then Save again.
- Go into Customizer. Ensure it loads without error. 

## Context
https://wordpress.org/support/topic/fatal-error-in-customizer-elementor/

## Original Error
<img width="1421" alt="Screen Shot 2022-08-24 at 10 30 41 PM" src="https://user-images.githubusercontent.com/68693/186527322-5c4f7efd-e12e-4d26-b3ee-97cd72e4113a.png">

